### PR TITLE
set up shared conda env on scc

### DIFF
--- a/scc-config/.condarc
+++ b/scc-config/.condarc
@@ -1,0 +1,7 @@
+envs_dirs:
+    - /rprojectnb/sparkpit/pit-seasonwatch/
+    - ~/.conda/envs
+pkgs_dirs:
+    - /rprojectnb/sparkpit/pit-seasonwatch/seasonwatch-ml-pkgs
+    - ~/.conda/pkgs
+env_prompt: ({name})

--- a/scc-config/README.md
+++ b/scc-config/README.md
@@ -1,0 +1,12 @@
+# SCC Conda Environment setup
+```
+# project directory
+cd /restricted/projectnb/sparkpit/pit-seasonwatch/pitne-season-watch
+
+# initialize .condarc
+bash scc-config/setup-condarc.sh
+
+# activate seasonwatch-ml conda environment
+module load miniconda/23.11.0
+conda activate /restricted/projectnb/sparkpit/pit-seasonwatch/seasonwatch-ml
+```

--- a/scc-config/setup-condarc.sh
+++ b/scc-config/setup-condarc.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+cp ./.condarc ~/.condarc


### PR DESCRIPTION
Initialize development environment on scc, which we will use to run clustering / outlier detection at scale! To review, follow instructions in `scc-config/README.md`, and make sure everything works for you.